### PR TITLE
Add ECR

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,67 @@
+---
+name: Terraform
+
+on:
+  pull_request:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Format
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: fmt
+          tf_actions_comment: true
+
+  terraform-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Init
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: init
+          tf_actions_comment: true
+      - name: Terraform Validate
+        uses: hashicorp/terraform-github-actions@master
+        env:
+          AWS_DEFAULT_REGION: eu-west-1
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: validate
+          tf_actions_comment: true
+
+  terraform-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Update module usage docs and push any changes back to PR branch
+        uses: Dirrk/terraform-docs@v1.0.8
+        with:
+          tf_docs_args: '--sort-inputs-by-required'
+          tf_docs_git_commit_message: 'terraform-docs: Update module usage'
+          tf_docs_git_push: 'true'
+          tf_docs_output_file: README.md
+          tf_docs_output_method: inject
+          tf_docs_find_dir: .
+
+  tfsec:
+    name: tfsec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform security scan
+        uses: triat/terraform-security-scan@v2.0.2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# terraform-aws-mcaf-ecr
+Terraform module to setup and manage AWS Elastic Container Registry (ECR) repositories.
+
+Example:
+
+```hcl
+module "ecr" {
+  source           = "git@github.com:schubergphilis/terraform-aws-mcaf-ecr.git"
+  repository_names = ["image-x", "namespace/image-y"]
+}
+```
+
+<!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | ~> 3.8.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 3.8.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| enable\_lifecycle\_policy | Set to false to prevent the module from adding any lifecycle policies to any repositories | `bool` | `true` | no |
+| image\_tag\_mutability | The tag mutability setting for the repository. Must be: `MUTABLE` or `IMMUTABLE` | `string` | `"IMMUTABLE"` | no |
+| max\_image\_days | Expire images older than the given number of days | `number` | `365` | no |
+| principals\_readonly\_access | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
+| repository\_names | list of repository names, names can include namespaces: prefixes ending with a slash (/) | `list(string)` | n/a | yes |
+| scan\_images\_on\_push | Indicates if images are automatically scanned after being pushed to the repository | `bool` | `true` | no |
+| tags | Mapping of tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+No output.
+
+<!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,86 @@
+locals {
+  ecr_need_policy = length(var.principals_readonly_access) > 0 ? true : false
+  policy_rule_remove_expired_image = [{
+    rulePriority = 2
+    description  = "Expire images older than ${var.max_image_days} days",
+    selection = {
+      tagStatus = "any"
+      countType = "sinceImagePushed"
+      "countUnit" : "days"
+      countNumber = var.max_image_days
+    }
+    action = {
+      type = "expire"
+    }
+  }]
+  policy_rule_untagged_image = [{
+    rulePriority = 1
+    description  = "Remove untagged images"
+    selection = {
+      tagStatus   = "untagged"
+      countType   = "imageCountMoreThan"
+      countNumber = 1
+    }
+    action = {
+      type = "expire"
+    }
+  }]
+}
+
+resource "aws_ecr_repository" "default" {
+  for_each             = toset(var.repository_names)
+  name                 = each.value
+  image_tag_mutability = var.image_tag_mutability
+  tags                 = var.tags
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_images_on_push
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "default" {
+  for_each   = toset(var.enable_lifecycle_policy ? var.repository_names : [])
+  repository = aws_ecr_repository.default[each.value].name
+
+  policy = jsonencode({
+    rules = concat(local.policy_rule_untagged_image, local.policy_rule_remove_expired_image)
+  })
+}
+
+data "aws_iam_policy_document" "default" {
+  count = local.ecr_need_policy ? 1 : 0
+
+  statement {
+    sid    = "ReadonlyAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = var.principals_readonly_access
+    }
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:DescribeImages",
+      "ecr:DescribeImageScanFindings",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:GetRepositoryPolicy",
+      "ecr:ListImages",
+      "ecr:ListTagsForResource"
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "default" {
+  for_each   = toset(local.ecr_need_policy ? var.repository_names : [])
+  repository = aws_ecr_repository.default[each.value].name
+  policy     = join("", data.aws_iam_policy_document.default.*.json)
+}

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,5 @@
 locals {
   ecr_need_policy = length(var.principals_readonly_access) > 0 ? true : false
-  policy_rule_remove_expired_image = [{
-    rulePriority = 2
-    description  = "Expire images older than ${var.max_image_days} days",
-    selection = {
-      tagStatus = "any"
-      countType = "sinceImagePushed"
-      "countUnit" : "days"
-      countNumber = var.max_image_days
-    }
-    action = {
-      type = "expire"
-    }
-  }]
   policy_rule_untagged_image = [{
     rulePriority = 1
     description  = "Remove untagged images"
@@ -47,7 +34,7 @@ resource "aws_ecr_lifecycle_policy" "default" {
   repository = aws_ecr_repository.default[each.value].name
 
   policy = jsonencode({
-    rules = concat(local.policy_rule_untagged_image, local.policy_rule_remove_expired_image)
+    rules = local.policy_rule_untagged_image
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,41 @@
+variable "enable_lifecycle_policy" {
+  type        = bool
+  description = "Set to false to prevent the module from adding any lifecycle policies to any repositories"
+  default     = true
+}
+
+variable "image_tag_mutability" {
+  type        = string
+  default     = "IMMUTABLE"
+  description = "The tag mutability setting for the repository. Must be: `MUTABLE` or `IMMUTABLE`"
+}
+
+variable "max_image_days" {
+  type        = number
+  default     = 365
+  description = "Expire images older than the given number of days"
+}
+
+variable "principals_readonly_access" {
+  type        = list(string)
+  default     = []
+  description = "Principal ARNs to provide with readonly access to the ECR"
+}
+
+variable "repository_names" {
+  type        = list(string)
+  description = "list of repository names, names can include namespaces: prefixes ending with a slash (/)"
+}
+
+variable "scan_images_on_push" {
+  type        = bool
+  default     = true
+  description = "Indicates if images are automatically scanned after being pushed to the repository"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Mapping of tags"
+}
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.8.0"
+    }
+  }
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Module for creating ECR repositories.
- ECR repository is created with encryption and image scanning enabled by default.
- Map for repository names to seperate the containers using namespaces.
- Added 1 best practise lifecycle policy rule (more can be added in the future, and there is a variable to turn this off)
- Added readonly access policy document for granting usage permission to other accounts