### PR TITLE
Remove unused variable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.2.3
+        uses: triat/terraform-security-scan@v3.0.0

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ module "ecr" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | repository\_names | list of repository names, names can include namespaces: prefixes ending with a slash (/) | `list(string)` | n/a | yes |
+| additional\_ecr\_policy\_statements | Map of additional ecr repository policy statements | <pre>map(object({<br>    effect = string<br>    principal = object({<br>      type        = string<br>      identifiers = list(string)<br>    })<br>    actions = list(string)<br>  }))</pre> | `null` | no |
 | enable\_lifecycle\_policy | Set to false to prevent the module from adding any lifecycle policies to any repositories | `bool` | `true` | no |
 | image\_tag\_mutability | The tag mutability setting for the repository. Must be: `MUTABLE` or `IMMUTABLE` | `string` | `"IMMUTABLE"` | no |
 | kms\_key\_arn | The KMS key ARN used for the repository encryption | `string` | `null` | no |
-| max\_image\_days | Expire images older than the given number of days | `number` | `365` | no |
 | principals\_readonly\_access | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
 | scan\_images\_on\_push | Indicates if images are automatically scanned after being pushed to the repository | `bool` | `true` | no |
 | tags | Mapping of tags | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,6 @@ variable "kms_key_arn" {
   description = "The KMS key ARN used for the repository encryption"
 }
 
-variable "max_image_days" {
-  type        = number
-  default     = 365
-  description = "Expire images older than the given number of days"
-}
-
 variable "principals_readonly_access" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
- max_image_days, was used in one of the default lifecycle policies, but this was removed in favor of the more flexible additional_ecr_policy_statements variable.