### PR TITLE
Enforce that there untagged images are not allowed within an ECR repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
     selection = {
       tagStatus   = "untagged"
       countType   = "imageCountMoreThan"
-      countNumber = 1
+      countNumber = 0
     }
     action = {
       type = "expire"


### PR DESCRIPTION
# Description

This PR updates the default life-cycle policy counter of untagged images to 0.
