### PR TITLE
Keep only one rule for managing untagged images

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,17 +3,6 @@ locals {
 
   policy_rule_untagged_image = [{
     rulePriority = 1
-    description  = "Keep only one untagged image, expire all others"
-    selection = {
-      tagStatus   = "untagged"
-      countType   = "imageCountMoreThan"
-      countNumber = 1
-    }
-    action = {
-      type = "expire"
-    }
-  },{
-    rulePriority = 2
     description  = "Keep untagged images for 1 day"
     selection = {
       tagStatus   = "untagged"


### PR DESCRIPTION
# Description

The evaluator of life-cycle policies does not allow to specify multiple
rules that select the same tagStatus; f.i. "untagged".

This PR removes one rule and promotes the one that deletes all
untagged images older than 1day since the last push event.