### PR TITLE
add option to prevent the ecr policy creation for a specific repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  for_each   = toset(local.ecr_policies != null ? var.repository_names : [])
+  for_each   = toset(local.ecr_policies != null ? [for k in var.repository_names : k if try(var.create_ecr_policy[k], true)] : [])
   repository = aws_ecr_repository.default[each.value].name
   policy     = join("", data.aws_iam_policy_document.default.*.json)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "additional_ecr_policy_statements" {
   default     = null
 }
 
+variable "create_ecr_policy" {
+  type        = map(bool)
+  description = "Set to false to prevent the module from creating the ecr repository policy"
+  default     = {}
+}
+
 variable "enable_lifecycle_policy" {
   type        = bool
   description = "Set to false to prevent the module from adding any lifecycle policies to any repositories"


### PR DESCRIPTION
add variable to disable the ecr policy creation for a specific repository

example:
```hcl

module "ecr" {
  source = "github.com/martijnvdp/terraform-aws-mcaf-ecr?ref=add-option-to-disable-repository-policy-creation"
  
  create_ecr_policy   = { for k, v in local.ecr_repositories : k => false if try(v.lambda, false) }
  repository_names  = [for k, v in local.ecr_repositories : k]
 ```