### PR TITLE
Fix: module failed when principals_readonly_access is provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "default" {
       effect  = title(statement.value.effect)
 
       dynamic "condition" {
-        for_each = statement.value.condition
+        for_each = try(statement.value.condition, {})
 
         content {
           test     = condition.value.test

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "default" {
       effect  = title(statement.value.effect)
 
       dynamic "condition" {
-        for_each = try(statement.value.condition, {})
+        for_each = try(statement.value.condition, [])
 
         content {
           test     = condition.value.test


### PR DESCRIPTION
When principals_readonly_access is provided with a list ["1234234435"] the module fails with the following error

```
│ Error: Unsupported attribute
│
│   on .terraform/modules/ecr/main.tf line 83, in data "aws_iam_policy_document" "default":
│   83:         for_each = statement.value.condition
│     ├────────────────
│     │ statement.value is object with 3 attributes
│
│ This object does not have an attribute named "condition".
```

Caused by `data "aws_iam_policy_document" "default"` that copies the policies.
But condition is not provided in the read-only policy and the policy fails.


Fix for this: 
```
      dynamic "condition" {
        for_each = try(statement.value.condition, [])
```

This will skip the condition part

