### PR TITLE
fix: Require at least one repository name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "principals_readonly_access" {
 variable "repository_names" {
   type        = list(string)
   description = "list of repository names, names can include namespaces: prefixes ending with a slash (/)"
+
+  validation {
+    condition     = length(var.repository_names) > 0
+    error_message = "At least one repository name must be provided"
+  }
 }
 
 variable "repository_tags" {


### PR DESCRIPTION
Without specifying a repository name, weird things happen. This PR adds a validation rule to require at least one repository name to be set.

Also included some style fixes.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
