### PR TITLE
fix: Fix default policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_ecr_lifecycle_policy" "default" {
 
 
 data "aws_iam_policy_document" "default" {
-  count = local.ecr_policies != null ? 1 : 0
+  count = length(local.ecr_policies) != 0 ? 1 : 0
 
   dynamic "statement" {
     for_each = local.ecr_policies


### PR DESCRIPTION
## :hammer_and_wrench: Summary

When deploying the ECR without permissions, the deployment breaks:

```txt
rror: putting ECR Repository Policy (xxx): operation error ECR: SetRepositoryPolicy, https response error StatusCode: 400, RequestID: xxx, InvalidParameterException: Invalid parameter at 'PolicyText' failed to satisfy constraint: 'Invalid repository policy provided'
with module.ect.aws_ecr_repository_policy.default["xxx"]
on .terraform/modules/xxx/main.tf line 113, in resource "aws_ecr_repository_policy" "default":
```

The Plan mentioned it as well:

<img width="751" height="251" alt="image" src="https://github.com/user-attachments/assets/f9ed6ccd-b442-432e-bdc0-7ecf2ff240b6" />

## :rocket: Motivation

The configuration makes a wrong assumption:

`ecr_policies = merge(local.readonly_ecr_policy, var.additional_ecr_policy_statements)`

A merge (in this case on 2 `null` values) returns a `{}`, so the check is always "true". Just change it into a length to check the amount of items in there

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
